### PR TITLE
add basic test

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,3 +21,7 @@
 platform = atmelavr
 framework = arduino
 board = megaatmega2560
+test_ignore = test_local
+
+[env:local]
+platform = native

--- a/src/errno_3.ino
+++ b/src/errno_3.ino
@@ -1,3 +1,5 @@
+#ifndef UNIT_TEST  // Enable unit tests
+
 #include <Adafruit_BNO055.h>
 #include <Adafruit_MCP9808.h>
 #include <Adafruit_Sensor.h>
@@ -277,3 +279,4 @@ void TaskGPSRead(void *pvParameters)
   }
 }
 
+#endif

--- a/test/test_local/test_local.cpp
+++ b/test/test_local/test_local.cpp
@@ -1,0 +1,19 @@
+#include "unity.h"
+
+#ifdef UNIT_TEST  // IMPORTANT LINE!
+
+void test_test(void) {
+    TEST_ASSERT_EQUAL(13, 13);
+}
+
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+    RUN_TEST(test_test);
+    UNITY_END();
+
+    return 0;
+}
+
+
+#endif


### PR DESCRIPTION
Adds platformio test folder, with sample test

This allows us to have multiple test suites, we can have one that runs locally on your own machine, and then another test suite to test code actually running on the arduino. More info can be found here: 
http://docs.platformio.org/en/stable/plus/unit-testing.html#unit-testing
- Note: In order to use the tests, platformio must be upgraded to version 3.
